### PR TITLE
feat(badxps): add Radarr service and update configurations

### DIFF
--- a/hosts/badxps/default.nix
+++ b/hosts/badxps/default.nix
@@ -6,7 +6,7 @@ let
   cfg = config.homelab.hosts.badxps;
   hostconfiguration = {
     description = "Dell XPS 9570 Latop";
-    dnsalias = [ "flood" "jellyfin" "prowlarr" "readarr" "sonarr" ];
+    dnsalias = [ "flood" "jellyfin" "prowlarr" "radarr" "readarr" "sonarr" ];
     icon =
       "https://nixos.wiki/images/thumb/2/20/Home-nixos-logo.png/207px-Home-nixos-logo.png";
     ipv4 = "192.168.254.114";

--- a/hosts/badxps/services/torrent.nix
+++ b/hosts/badxps/services/torrent.nix
@@ -76,6 +76,13 @@ in
   # Indexers
   services.prowlarr = { enable = true; };
 
+  # Movies
+  services.radarr = {
+    enable = true;
+    user = "qbittorrent-nox";
+    group = "media";
+  };
+
   # Ebooks
   services.readarr = {
     enable = true;

--- a/hosts/badxps/services/traefik.nix
+++ b/hosts/badxps/services/traefik.nix
@@ -4,6 +4,7 @@ let
   localIp = config.homelab.currentHost.ipv4;
 in
 {
+  networking.firewall.allowedTCPPorts = [ 80 ];
 
   services.traefik = {
     enable = true;
@@ -36,14 +37,19 @@ in
           service = "jellyfin";
           entryPoints = [ "local" ];
         };
-        sonarr = {
-          rule = lib.mkDefault "Host(`sonarr.${domain}`)";
-          service = "sonarr";
-          entryPoints = [ "local" ];
-        };
         prowlarr = {
           rule = lib.mkDefault "Host(`prowlarr.${domain}`)";
           service = "prowlarr";
+          entryPoints = [ "local" ];
+        };
+        radarr = {
+          rule = lib.mkDefault "Host(`radarr.${domain}`)";
+          service = "radarr";
+          entryPoints = [ "local" ];
+        };
+        sonarr = {
+          rule = lib.mkDefault "Host(`sonarr.${domain}`)";
+          service = "sonarr";
           entryPoints = [ "local" ];
         };
       };
@@ -52,11 +58,14 @@ in
         jellyfin = {
           loadBalancer = { servers = [{ url = "http://localhost:8096"; }]; };
         };
-        sonarr = {
-          loadBalancer = { servers = [{ url = "http://localhost:8989"; }]; };
-        };
         prowlarr = {
           loadBalancer = { servers = [{ url = "http://localhost:9696"; }]; };
+        };
+        radarr = {
+          loadBalancer = { servers = [{ url = "http://localhost:7878"; }]; };
+        };
+        sonarr = {
+          loadBalancer = { servers = [{ url = "http://localhost:8989"; }]; };
         };
       };
     };


### PR DESCRIPTION
- Added Radarr service to `services/torrent.nix` with appropriate user and group settings.
- Included Radarr in the `dnsalias` list in `default.nix`.
- Configured Traefik to route traffic for Radarr in `services/traefik.nix`.
- Adjusted formatting for consistency in multiple files.