### PR TITLE
feat(hosts/b4d14): configure Docker to use ZFS storage driver

### DIFF
--- a/hosts/b4d14/default.nix
+++ b/hosts/b4d14/default.nix
@@ -35,8 +35,7 @@ let
       };
     };
   };
-in
-{
+in {
   imports = [
     # https://github.com/NixOS/nixos-hardware/tree/master/dell/xps/15-9520
     inputs.hardware.nixosModules.dell-xps-15-9520
@@ -123,6 +122,8 @@ in
       true; # # If compatibility with 32-bit applications is desired
     #extraConfig = "load-module module-combine-sink";
   };
+
+  virtualisation.docker = { storageDriver = "zfs"; };
 
   ####################################
   # Programs


### PR DESCRIPTION
Added a configuration for Docker to use the ZFS storage driver in the `b4d14` host's NixOS configuration. Also reformatted the `in` block for consistency.