### PR TITLE
feat(home-manager): add Neovim configuration and language support

### DIFF
--- a/nix/home-manager/apps/editor/neovim.nix
+++ b/nix/home-manager/apps/editor/neovim.nix
@@ -1,0 +1,52 @@
+{ pkgs, ... }: {
+
+  # Clone the https://github.com/badele/vide to ~/.config/nvim
+  programs.neovim = {
+    enable = true;
+
+    viAlias = true;
+    vimAlias = true;
+    vimdiffAlias = true;
+  };
+
+  # All neovim plugins list from the https://github.com/badele/vide project
+  home.packages = with pkgs; [
+    # vide project requirements
+    pre-commit
+
+    # neovim and plugins build requirements
+    cargo
+    cmake
+    curl
+    ncurses
+    nodejs
+    unzip
+    yarn
+
+    # Need by plugins
+    fd
+    lazygit
+    ripgrep
+    tree-sitter
+    xclip
+
+    # Language support packages are now in separate files:
+    # - nix/home-manager/features/language/ansible.nix
+    # - nix/home-manager/features/language/bash.nix
+    # - nix/home-manager/features/language/c.nix
+    # - nix/home-manager/features/language/d2.nix
+    # - nix/home-manager/features/language/go.nix
+    # - nix/home-manager/features/language/javascript.nix
+    # - nix/home-manager/features/language/latex.nix
+    # - nix/home-manager/features/language/ledger.nix
+    # - nix/home-manager/features/language/lua.nix
+    # - nix/home-manager/features/language/markdown.nix
+    # - nix/home-manager/features/language/nix.nix
+    # - nix/home-manager/features/language/openscad.nix
+    # - nix/home-manager/features/language/python.nix
+    # - nix/home-manager/features/language/scala.nix
+    # - nix/home-manager/features/language/terraform.nix
+    # - nix/home-manager/features/language/yaml.nix
+  ];
+
+}

--- a/nix/home-manager/features/language/all.nix
+++ b/nix/home-manager/features/language/all.nix
@@ -1,0 +1,20 @@
+{ ... }: {
+  imports = [
+    ./ansible.nix
+    ./bash.nix
+    ./c.nix
+    ./d2.nix
+    ./go.nix
+    ./javascript.nix
+    ./latex.nix
+    ./ledger.nix
+    ./lua.nix
+    ./markdown.nix
+    ./nix.nix
+    ./openscad.nix
+    ./python.nix
+    ./scala.nix
+    ./terraform.nix
+    ./yaml.nix
+  ];
+}

--- a/nix/home-manager/features/language/ansible.nix
+++ b/nix/home-manager/features/language/ansible.nix
@@ -1,0 +1,2 @@
+{ pkgs, ... }: { home.packages = with pkgs; [ ansible-lint ]; }
+

--- a/nix/home-manager/features/language/bash.nix
+++ b/nix/home-manager/features/language/bash.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    # Bash
+    nodePackages.bash-language-server
+    shellcheck
+    shfmt
+    
+    # Makefile
+    checkmake
+  ];
+}

--- a/nix/home-manager/features/language/d2.nix
+++ b/nix/home-manager/features/language/d2.nix
@@ -1,0 +1,2 @@
+{ pkgs, ... }: { home.packages = with pkgs; [ d2 ]; }
+

--- a/nix/home-manager/features/language/javascript.nix
+++ b/nix/home-manager/features/language/javascript.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    # JavaScript/TypeScript
+    nodejs
+    yarn
+    deno
+    nodePackages.eslint
+    nodePackages.prettier
+    
+    # JSON
+    vscode-langservers-extracted
+    nodePackages.fixjson
+    nodePackages.jsonlint
+    
+    # Dockerfile
+    nodePackages.dockerfile-language-server-nodejs
+  ];
+}

--- a/nix/home-manager/features/language/latex.nix
+++ b/nix/home-manager/features/language/latex.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    # LaTeX
+    (texlive.combine {
+      inherit (texlive) scheme-medium tabularray ninecolors msg lipsum pgf;
+    })
+    biber
+    pplatex
+    pstree
+    texlab
+    xdotool
+    zathura
+  ];
+}

--- a/nix/home-manager/features/language/ledger.nix
+++ b/nix/home-manager/features/language/ledger.nix
@@ -1,0 +1,1 @@
+{ pkgs, ... }: { home.packages = with pkgs; [ ledger hledger ]; }

--- a/nix/home-manager/features/language/lua.nix
+++ b/nix/home-manager/features/language/lua.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    # Lua
+    lua51Packages.lua
+    lua-language-server
+    stylua
+    luaformatter
+    luajitPackages.luacheck
+    luajitPackages.luarocks
+    luajitPackages.jsregexp
+    selene
+  ];
+}

--- a/nix/home-manager/features/language/markdown.nix
+++ b/nix/home-manager/features/language/markdown.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    # Markdown
+    marksman
+    nodePackages.markdownlint-cli
+  ];
+}

--- a/nix/home-manager/features/language/nix.nix
+++ b/nix/home-manager/features/language/nix.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    # Nix
+    alejandra
+    deadnix
+    nixd
+    nil
+    nixfmt
+    nixpkgs-fmt
+    statix
+  ];
+}

--- a/nix/home-manager/features/language/openscad.nix
+++ b/nix/home-manager/features/language/openscad.nix
@@ -1,0 +1,2 @@
+{ pkgs, ... }: { home.packages = with pkgs; [ openscad openscad-lsp ]; }
+

--- a/nix/home-manager/features/language/python.nix
+++ b/nix/home-manager/features/language/python.nix
@@ -1,3 +1,18 @@
-{ pkgs, ... }:
-let pythonEnv = pkgs.python313.withPackages (p: with p; [ pip requests ]);
-in { home.packages = [ pythonEnv ]; }
+{ pkgs, ... }: {
+  home.packages = with pkgs; [
+    ruff
+    (python313.withPackages (ps:
+      with ps; [
+        pip
+        requests
+
+        # Used by VIDE project (https://github.com/badele/vide)
+        pycodestyle
+        pydocstyle
+        pylint
+        mypy
+        vulture
+        mdformat
+      ]))
+  ];
+}

--- a/nix/home-manager/features/language/scala.nix
+++ b/nix/home-manager/features/language/scala.nix
@@ -1,0 +1,2 @@
+{ pkgs, ... }: { home.packages = with pkgs; [ sbt metals ]; }
+

--- a/nix/home-manager/features/language/terraform.nix
+++ b/nix/home-manager/features/language/terraform.nix
@@ -1,0 +1,2 @@
+{ pkgs, ... }: { home.packages = with pkgs; [ terraform terraform-ls ]; }
+

--- a/nix/home-manager/features/language/yaml.nix
+++ b/nix/home-manager/features/language/yaml.nix
@@ -1,0 +1,2 @@
+{ pkgs, ... }: { home.packages = with pkgs; [ yaml-language-server ]; }
+

--- a/users/badele/b4d14.nix
+++ b/users/badele/b4d14.nix
@@ -29,9 +29,7 @@ in {
 
     # Language
     ../../nix/home-manager/apps/cloud/aws.nix
-    ../../nix/home-manager/features/language/c.nix
-    ../../nix/home-manager/features/language/go.nix
-    ../../nix/home-manager/features/language/python.nix
+    ../../nix/home-manager/features/language/all.nix
 
     # Desktop
     ../../nix/home-manager/features/desktop/apps/base.nix

--- a/users/badele/badxps.nix
+++ b/users/badele/badxps.nix
@@ -10,8 +10,7 @@ let
     COLOR="#"$COLOR
     ${pkgs.imagemagick}/bin/magick convert -size 1920x1080 xc:$COLOR $out
   '';
-in
-{
+in {
   imports = [
     # homelab Modules
     ../../nix/modules/home-manager/font.nix
@@ -36,9 +35,7 @@ in
     ../../nix/home-manager/features/term/security
 
     # Language
-    ../../nix/home-manager/features/language/c.nix
-    ../../nix/home-manager/features/language/go.nix
-    ../../nix/home-manager/features/language/python.nix
+    ../../nix/home-manager/features/language/all.nix
 
     # Desktop
     ../../nix/home-manager/features/desktop/apps/base.nix

--- a/users/badele/commons.nix
+++ b/users/badele/commons.nix
@@ -6,6 +6,7 @@
   imports = [
     # Apps
     ../../nix/home-manager/apps/tools.nix
+    ../../nix/home-manager/apps/editor/neovim.nix
     ../../nix/home-manager/apps/development/packages.nix
     ../../nix/home-manager/apps/development/aider.nix
     ../../nix/home-manager/apps/development/internet.nix


### PR DESCRIPTION
- Added `neovim.nix` to configure Neovim and its dependencies.
- Introduced `language/all.nix` to aggregate language-specific configurations.
- Added individual language support files for Ansible, Bash, D2, JavaScript, LaTeX, Ledger, Lua, Markdown, Nix, OpenSCAD, Python, Scala, Terraform, and YAML.
- Updated user configurations (`b4d14.nix`, `badxps.nix`, `commons.nix`) to use the new `language/all.nix` and include Neovim setup.